### PR TITLE
Bugfix: make `Component.remap_layers` actually return a copy

### DIFF
--- a/gdsfactory/component.py
+++ b/gdsfactory/component.py
@@ -2350,7 +2350,7 @@ class Component(_GeometryHelper):
         if kwargs:
             warnings.warn("{kwargs.keys} is deprecated.", DeprecationWarning)
 
-        component = self
+        component = self.copy()
         layermap = {_parse_layer(k): _parse_layer(v) for k, v in layermap.items()}
 
         cells = list(component.get_dependencies(True))


### PR DESCRIPTION
`Component.remap_layers` says it returns a copy of the component with remapped layers but it actually remaps the layers in-place. This pull request fixes this inconsistency by copying the component before the remap.